### PR TITLE
Fix/maintain system registration fields

### DIFF
--- a/cidaas/resource_registration_field.go
+++ b/cidaas/resource_registration_field.go
@@ -298,5 +298,11 @@ func prepareRegistrationFieldConfig(d *schema.ResourceData) cidaas.RegistrationF
 	registrationFieldConfig.FieldDefinition.Language = d.Get("locale_text_language").(string)
 	registrationFieldConfig.FieldDefinition.MinLength = d.Get("locale_text_min_length").(int)
 	registrationFieldConfig.FieldDefinition.MaxLength = d.Get("locale_text_max_length").(int)
+
+	className := "FieldSetup"
+	if registrationFieldConfig.FieldType == "SYSTEM" {
+		className = "de.cidaas.core.db.RegistrationFieldSetup"
+	}
+	registrationFieldConfig.ClassName = className
 	return registrationFieldConfig
 }

--- a/helper/cidaas/resource-registration-field.go
+++ b/helper/cidaas/resource-registration-field.go
@@ -39,15 +39,15 @@ type GetRegistrationFieldConfig struct {
 }
 
 type RegistrationFieldConfig struct {
-	Internal        bool            `json:"internal,omitempty"`
-	ReadOnly        bool            `json:"readOnly,omitempty"`
-	Claimable       bool            `json:"claimable,omitempty"`
-	Required        bool            `json:"required,omitempty"`
+	Internal        bool            `json:"internal"`
+	ReadOnly        bool            `json:"readOnly"`
+	Claimable       bool            `json:"claimable"`
+	Required        bool            `json:"required"`
 	Scopes          []string        `json:"scopes,omitempty"`
-	Enabled         bool            `json:"enabled,omitempty"`
+	Enabled         bool            `json:"enabled"`
 	LocaleText      LocaleText      `json:"localeText,omitempty"`
-	IsGroup         bool            `json:"is_group,omitempty"`
-	IsList          bool            `json:"is_list,omitempty"`
+	IsGroup         bool            `json:"is_group"`
+	IsList          bool            `json:"is_list"`
 	ParentGroupId   string          `json:"parent_group_id,omitempty"`
 	FieldType       string          `json:"fieldType,omitempty"`
 	Id              string          `json:"_id,omitempty"`
@@ -56,6 +56,7 @@ type RegistrationFieldConfig struct {
 	Order           int             `json:"order,omitempty"`
 	BaseDataType    string          `json:"baseDataType,omitempty"`
 	FieldDefinition FieldDefinition `json:"fieldDefinition,omitempty"`
+	ClassName       string          `json:"className,omitempty"`
 }
 
 type FieldDefinition struct {


### PR DESCRIPTION
This PR fixes two issues regarding the integration registration fields into terraform.

1. The field `className` from the cidaas fields api was omitted which lead to the use of the default class name of `FieldSetup` in cidaas even if the correct class name  for fields of type `SYSTEM` is `de.cidaas.core.db.RegistrationFieldSetup` AFAIU. This made `System` fields unusable when defined in TF. The change sets `className` based on the field type (SYSTEM or CUSTOM). 

IMHO this should be fixed on the cidaas api level as the `className` field is not documented in the API documentation and seems to be some internal field an api user should have no business messing around with.

2. The serialization of the `RegistrationFieldConfig`  was broken for boolean. The field tag `json:"someField,omitempty"` in conjunction with booleans leads to booleans with the value `false` to be omitted.  This lead to fields not to be editable via the admin UI. As all the values are configured as required in the TF schema there is no need for to omit empty fields here. 